### PR TITLE
Feature/#10 - ExceptionHandler 관련 GlobalExceptionRestAdvice 메서드 추가 및 내용 수정 

### DIFF
--- a/src/main/java/com/FC/SharedOfficePlatform/global/exception/GlobalExceptionRestAdvice.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/global/exception/GlobalExceptionRestAdvice.java
@@ -1,17 +1,28 @@
 package com.FC.SharedOfficePlatform.global.exception;
 
 import com.FC.SharedOfficePlatform.global.util.ResponseDTO;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionRestAdvice {
 
+    // @ExceptionHandler annotation을 누락시켜서, Custom Exception 대신 INTERNAL_SERVER_ERROR가 나왔었음.
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ResponseDTO<Void>> applicationException(ApplicationException e) {
         log.error(e.getMessage(), e);
@@ -20,13 +31,48 @@ public class GlobalExceptionRestAdvice {
             .body(ResponseDTO.error(e.getErrorCode()));
     }
 
-    @ExceptionHandler(BindException.class)
-    public ResponseEntity<ResponseDTO<Void>> bindException(BindException e) {
+    // Request Body 형식이 틀린 경우, 400 (BAD_REQUEST) 에러 띄우도록 함 - 초기 셋업 이후, 24.05.19 추가
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ResponseDTO<Void>> httpMessageNotReadableException(
+        HttpMessageNotReadableException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST,
-                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+            .body(ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    //DTO Validation 실패 시 어떤 정보가 잘못 됐는지 메시지 자세히 출력 - 초기 셋업 이후, 24.05.19 추가
+    //bindException ~ getSortedFiledErrors
+    @ExceptionHandler(BindException.class)
+    public ResponseDTO<Void> bindException(BindException e) {
+        log.warn("[bindException] Message = {}",
+            NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+
+        BindingResult bindingResult = e.getBindingResult();
+        List<FieldError> fieldErrors = getSortedFieldErrors(bindingResult);
+
+        String response = fieldErrors.stream()
+            .map(fieldError -> String.format("%s (%s=%s)",
+                    fieldError.getDefaultMessage(),
+                    fieldError.getField(),
+                    fieldError.getRejectedValue()
+                )
+            ).collect(Collectors.joining(", "));
+        return ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST, response);
+    }
+
+    //DTO Validation 실패 시 어떤 정보가 잘못 됐는지 메시지 자세히 출력 - 초기 셋업 이후, 24.05.19 추가
+    //bindException ~ getSortedFiledErrors
+    private List<FieldError> getSortedFieldErrors(BindingResult bindingResult) {
+        List<String> declaredFields = Arrays.stream(
+                Objects.requireNonNull(bindingResult.getTarget()).getClass().getDeclaredFields())
+            .map(Field::getName)
+            .toList();
+
+        return bindingResult.getFieldErrors().stream()
+            .filter(fieldError -> declaredFields.contains(fieldError.getField()))
+            .sorted(Comparator.comparingInt(fe -> declaredFields.indexOf(fe.getField())))
+            .collect(Collectors.toList());
     }
 
     @ExceptionHandler(DataAccessException.class)
@@ -34,7 +80,7 @@ public class GlobalExceptionRestAdvice {
         log.error(e.getMessage(), e);
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ResponseDTO.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
+            .body(ResponseDTO.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "디비 에러!"));
     }
 
     @ExceptionHandler(RuntimeException.class)
@@ -45,4 +91,3 @@ public class GlobalExceptionRestAdvice {
             .body(ResponseDTO.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
     }
 }
-

--- a/src/main/java/com/FC/SharedOfficePlatform/global/exception/GlobalExceptionRestAdvice.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/global/exception/GlobalExceptionRestAdvice.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionRestAdvice {
 
+    @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ResponseDTO<Void>> applicationException(ApplicationException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity
@@ -19,7 +20,7 @@ public class GlobalExceptionRestAdvice {
             .body(ResponseDTO.error(e.getErrorCode()));
     }
 
-    @ExceptionHandler
+    @ExceptionHandler(BindException.class)
     public ResponseEntity<ResponseDTO<Void>> bindException(BindException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity
@@ -28,7 +29,7 @@ public class GlobalExceptionRestAdvice {
                 e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
     }
 
-    @ExceptionHandler
+    @ExceptionHandler(DataAccessException.class)
     public ResponseEntity<ResponseDTO<Void>> dbException(DataAccessException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity
@@ -36,7 +37,7 @@ public class GlobalExceptionRestAdvice {
             .body(ResponseDTO.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
     }
 
-    @ExceptionHandler
+    @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ResponseDTO<Void>> serverException(RuntimeException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity


### PR DESCRIPTION
## ⭐ 개요

### 종류
- [o] New Feature
- [o] Bug Fix

### 📑 주요 작성/변경사항
1. 커스텀 에러 메시지 대신 INTERNAL_SERVER_ERROR 뜨던 오류 해결
 applicationException에 @ExceptionHandler가 누락되어 있었음.

: + 명시적으로 각각의 Exception을 체크하기 위해서 @ExceptionHandler(XXXException.class) 추가하였음.

3. HttpMessageNotReadableException,  BindException 메서드 추가 및 내용 수정

 :HttpMessageNotReadableException
 Request Body 형식이 틀린 경우, 400 (BAD_REQUEST) 에러 띄우도록 함

 :BindException(+getSortedFieldErrors)
 DTO Validation 실패 시 어떤 정보가 잘못 됐는지 메시지 자세히 출력

![image](https://github.com/FC-SharedOffice-5/BE_SharedOffice/assets/129931655/cc6e5afe-27cd-496f-82fa-adba812aa0cb)

