### PR TITLE
회원 ~ 이메일 기능 관련 수정 (오류 수정 및 필드 추가) #38

### DIFF
--- a/src/main/java/com/FC/SharedOfficePlatform/domain/member/dto/request/SendEmailRequest.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/domain/member/dto/request/SendEmailRequest.java
@@ -1,6 +1,11 @@
 package com.FC.SharedOfficePlatform.domain.member.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
 public record SendEmailRequest(
+    @NotNull(message = "이메일을 입력해 주세요.")
+    @Email(message = "이메일 형식이 유효하지 않습니다.")
     String email
 ) {
 

--- a/src/main/java/com/FC/SharedOfficePlatform/domain/member/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/domain/member/dto/request/UpdatePasswordRequest.java
@@ -2,10 +2,11 @@ package com.FC.SharedOfficePlatform.domain.member.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record UpdatePasswordRequest(
-    @NotNull(message = "이메일을 입력해 주세요.")
-    @Email(message = "이메일 형식이 유효하지 않습니다.")
+    @NotNull(message = "비밀 번호를 입력해 주세요.")
+    @Size(min = 8, message = "비밀 번호는 8자 이상 20자 이하입니다.")
     String password
 ) {
 

--- a/src/main/java/com/FC/SharedOfficePlatform/domain/member/entity/Member.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/domain/member/entity/Member.java
@@ -33,6 +33,9 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(name = "department")
+    private String department;
+
     @Column(name = "use_yn", columnDefinition = "TINYINT(1)")
     private Boolean useYn;
 
@@ -42,7 +45,7 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_nickname", length = 25)
     private String memberNickname;
 
-    @Column(name = "number_gender", columnDefinition = "TINYINT(1)")
+    @Column(name = "member_gender", columnDefinition = "TINYINT(1)")
     private Boolean memberGender;
 
     @Column(name = "member_birth")
@@ -58,12 +61,13 @@ public class Member extends BaseTimeEntity {
     private Boolean pushAgree;
 
     @Builder
-    public Member(String email, String password, Role role, Boolean useYn, String memberName,
-        String memberNickname, Boolean memberGender, LocalDate memberBirth, Boolean emailAgree,
-        Boolean messageAgree, Boolean pushAgree) {
+    public Member(String email, String password, Role role, String department, Boolean useYn,
+        String memberName, String memberNickname, Boolean memberGender, LocalDate memberBirth,
+        Boolean emailAgree, Boolean messageAgree, Boolean pushAgree) {
         this.email = email;
         this.password = password;
         this.role = role;
+        this.department = department;
         this.useYn = useYn;
         this.memberName = memberName;
         this.memberNickname = memberNickname;

--- a/src/main/java/com/FC/SharedOfficePlatform/global/security/SecurityConfig.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/global/security/SecurityConfig.java
@@ -42,10 +42,12 @@ public class SecurityConfig {
             )
             .securityMatcher("/**")
             .authorizeHttpRequests(
-                registry -> registry
+                authorize -> authorize
                     .requestMatchers(HttpMethod.POST, "/members/signup").permitAll()
+                    .requestMatchers(HttpMethod.PUT, "/members/update/pw/{id}").permitAll()
                     .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
-                    .requestMatchers(HttpMethod.POST, "/email/**").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/email/send/code").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/email/**").permitAll()
                     .anyRequest().authenticated()
             );
         return http.build();
@@ -64,3 +66,5 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 }
+
+


### PR DESCRIPTION
## ⭐ 개요

### 종류
- [ ] New Feature
- [x] Bug Fix
- [ ] CI/CD
- [ ] Setup

### 📑 주요 작성/변경사항
1.UpdatePasswordRequest
 validation 형식에서 비밀번호 필드에 이메일 관련 내용이 있어 수정

2.refactor : SendEmailRequest 수정
email 필드의 @NotNull, @Email validation 추가

3. Member Entity 수정
부서 department 필드 추가
member_gender에 column 명의 오류 수정

4. SecurityConfig 수정
인증번호 보내기, 이메일 인증, 비밀번호 수정 API의 URL 허용
authorizeHttpRequests의 registry로 되어있던 변수명 authorize로 수정

### 💡 특이 사항

### #️⃣ Issue Link - #12

### Reference
