### PR TITLE
refactor: 이메일 인증 smtp 주소 재설정 (naver -> gmail)

### DIFF
--- a/src/main/java/com/FC/SharedOfficePlatform/global/config/JavaMailConfig.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/global/config/JavaMailConfig.java
@@ -20,7 +20,7 @@ public class JavaMailConfig {
     @Bean
     public JavaMailSender getJavaMailSender() {
         JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-        mailSender.setHost("smtp.naver.com");
+        mailSender.setHost("smtp.gmail.com");
         mailSender.setPort(465);
         mailSender.setUsername(emailId);
         mailSender.setPassword(emailPassword);


### PR DESCRIPTION
상세설명
1. smtp.naver.com -> smtp.gmail.com

## ⭐ 개요

### 종류
- [ ] New Feature
- [ ] Bug Fix
- [ ] CI/CD
- [ ] Setup

### 📑 주요 작성/변경사항
- []
- []

### 💡 특이 사항

### #️⃣ Issue Link - #12

### Reference
