### PR TITLE
#83 파일 이미지 API - 멤버에 해당하는 이미지 등록, 조회 API 

### DIFF
--- a/src/main/java/com/FC/SharedOfficePlatform/domain/image/controller/ImageDataController.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/domain/image/controller/ImageDataController.java
@@ -1,12 +1,14 @@
 package com.FC.SharedOfficePlatform.domain.image.controller;
 
 import com.FC.SharedOfficePlatform.domain.image.dto.ImageDataResponse;
+import com.FC.SharedOfficePlatform.domain.image.entity.ImageData;
 import com.FC.SharedOfficePlatform.domain.image.service.ImageDataService;
 import com.FC.SharedOfficePlatform.global.util.ResponseDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -29,9 +31,12 @@ public class ImageDataController {
 
     @PostMapping
     public ResponseEntity<ResponseDTO<ImageDataResponse>> uploadImage(
-        @RequestParam("images") MultipartFile file, HttpServletRequest request
+        @RequestParam("images") MultipartFile file,
+        @RequestParam("entityType") String entityType,
+        @RequestParam("entityId") Long entityId,
+        HttpServletRequest request
     ) throws IOException, NoSuchAlgorithmException {
-        ImageDataResponse response = imageDataService.uploadImage(file, request);
+        ImageDataResponse response = imageDataService.uploadImage(file, entityType, entityId, request);
         return ResponseEntity.ok(ResponseDTO.okWithData(response));
     }
 
@@ -80,6 +85,16 @@ public class ImageDataController {
         imageDataService.deleteImage(imageId);
         return ResponseEntity.ok(ResponseDTO.ok());
     }
+
+    @GetMapping("/member/{memberId}")
+    public ResponseEntity<ResponseDTO<List<ImageDataResponse>>> getImagesByMember(@PathVariable Long memberId) {
+        List<ImageData> imagesByMember = imageDataService.getImagesByMember(memberId);
+        List<ImageDataResponse> responses = imagesByMember.stream()
+            .map(ImageDataResponse::from)
+            .collect(Collectors.toList());
+        return ResponseEntity.ok(ResponseDTO.okWithData(responses));
+    }
+
 }
 
 

--- a/src/main/java/com/FC/SharedOfficePlatform/domain/image/dto/ImageDataResponse.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/domain/image/dto/ImageDataResponse.java
@@ -4,13 +4,16 @@ import com.FC.SharedOfficePlatform.domain.image.entity.ImageData;
 public record ImageDataResponse(
     Long imageId,
     String fileName,
-    String url
+    String url,
+    Long memberId
 ) {
     public static ImageDataResponse from(ImageData imageData) {
+        Long memberId = (imageData.getMember() != null) ? imageData.getMember().getId() : null;
         return new ImageDataResponse(
             imageData.getId(),
             imageData.getName(),
-            imageData.getUrl()
+            imageData.getUrl(),
+            memberId
         );
     }
 }

--- a/src/main/java/com/FC/SharedOfficePlatform/domain/image/entity/ImageData.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/domain/image/entity/ImageData.java
@@ -1,12 +1,15 @@
 package com.FC.SharedOfficePlatform.domain.image.entity;
 
+import com.FC.SharedOfficePlatform.domain.member.entity.Member;
 import com.FC.SharedOfficePlatform.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,12 +39,17 @@ public class ImageData extends BaseTimeEntity {
     // New field for storing the URL
     private String url;
 
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     @Builder
-    public ImageData(String name, String type, String hash, byte[] imageData, String url) {
+    public ImageData(String name, String type, String hash, byte[] imageData, String url, Member member) {
         this.name = name;
         this.type = type;
         this.hash = hash;
         this.imageData = imageData;
         this.url = url;
+        this.member = member;
     }
 }

--- a/src/main/java/com/FC/SharedOfficePlatform/domain/image/repository/ImageDataRepository.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/domain/image/repository/ImageDataRepository.java
@@ -1,6 +1,8 @@
 package com.FC.SharedOfficePlatform.domain.image.repository;
 
 import com.FC.SharedOfficePlatform.domain.image.entity.ImageData;
+import com.FC.SharedOfficePlatform.domain.member.entity.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,5 +13,7 @@ public interface ImageDataRepository extends JpaRepository<ImageData ,Long> {
     Optional<ImageData> findByName(String fileName);
 
     Optional<ImageData> findByHash(String hash);
+
+    List<ImageData> findByMember(Member member);
 
 }

--- a/src/main/java/com/FC/SharedOfficePlatform/domain/member/entity/Member.java
+++ b/src/main/java/com/FC/SharedOfficePlatform/domain/member/entity/Member.java
@@ -1,7 +1,9 @@
 package com.FC.SharedOfficePlatform.domain.member.entity;
 
+import com.FC.SharedOfficePlatform.domain.image.entity.ImageData;
 import com.FC.SharedOfficePlatform.global.common.BaseTimeEntity;
 import com.FC.SharedOfficePlatform.global.security.enums.Role;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,7 +11,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -60,10 +65,13 @@ public class Member extends BaseTimeEntity {
     @Column(name = "push_agree", columnDefinition = "TINYINT(1)")
     private Boolean pushAgree;
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ImageData> images = new ArrayList<>();
+
     @Builder
     public Member(String email, String password, Role role, String department, Boolean useYn,
         String memberName, String memberNickname, Boolean memberGender, LocalDate memberBirth,
-        Boolean emailAgree, Boolean messageAgree, Boolean pushAgree) {
+        Boolean emailAgree, Boolean messageAgree, Boolean pushAgree, List<ImageData> images) {
         this.email = email;
         this.password = password;
         this.role = role;
@@ -76,6 +84,9 @@ public class Member extends BaseTimeEntity {
         this.emailAgree = emailAgree;
         this.messageAgree = messageAgree;
         this.pushAgree = pushAgree;
+        if (images != null) {
+            this.images = images;
+        }
     }
 
     public void updatePassword(String newPassword) {


### PR DESCRIPTION
## ⭐ 개요
* POST method는 entityType, entityId라는 ReqeustParam을 추가하여, 멤버 뿐 아니라, 이후 게시판의 entity와 id를 활용할 수 있도록
설정 (등록시 각 entity에 연관하는 이미지 저장가능 )

* 멤버에 해당하는 이미지를 조회하려면, 해당 memberId로 조회하는 GET method가 하나 더 추가되어야 하므로, 해당 부분 추가

### 종류
- [x] New Feature

### 📑 주요 작성/변경사항

![image](https://github.com/FC-SharedOffice-5/BE_SharedOffice/assets/129931655/0ee8f4f6-782a-42ad-a99b-89e94433dfe5)


![image](https://github.com/FC-SharedOffice-5/BE_SharedOffice/assets/129931655/25a85c99-e2d0-4f73-9993-41713c22f8ef)

DB 사진
![image](https://github.com/FC-SharedOffice-5/BE_SharedOffice/assets/129931655/400c7b09-fa7a-4b26-b5f1-d203c081180a)


### 💡 특이 사항



### #️⃣ Issue Link - #12

### Reference
